### PR TITLE
fix: install github cli in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,13 @@
-FROM alpine:3.19
+FROM alpine:3.15
+
+RUN apk add --no-cache curl tar gzip && \
+    curl -LO https://github.com/cli/cli/releases/download/v2.4.0/gh_2.4.0_linux_amd64.tar.gz && \
+    tar xvf gh_2.4.0_linux_amd64.tar.gz && \
+    mv gh_2.4.0_linux_amd64/bin/gh /usr/local/bin && \
+    rm -rf gh_2.4.0_linux_amd64 gh_2.4.0_linux_amd64.tar.gz
 
 ADD entrypoint.sh /entrypoint.sh
+
 RUN chmod +x /entrypoint.sh
+
 ENTRYPOINT ["/entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM alpine:3.15
 
+ARG GH_VERSION=2.4.0
+
 RUN apk add --no-cache curl tar gzip && \
-    curl -LO https://github.com/cli/cli/releases/download/v2.4.0/gh_2.4.0_linux_amd64.tar.gz && \
-    tar xvf gh_2.4.0_linux_amd64.tar.gz && \
-    mv gh_2.4.0_linux_amd64/bin/gh /usr/local/bin && \
-    rm -rf gh_2.4.0_linux_amd64 gh_2.4.0_linux_amd64.tar.gz
+    curl -LO "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" && \
+    tar xvf "gh_${GH_VERSION}_linux_amd64.tar.gz" && \
+    mv "gh_${GH_VERSION}_linux_amd64/bin/gh" /usr/local/bin && \
+    rm -rf "gh_${GH_VERSION}_linux_amd64" "gh_${GH_VERSION}_linux_amd64.tar.gz"
 
 ADD entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
After trying it out I found out that the entrypoint does not recognize the gh cli so I installed it in the dockerfile to use it directly.

![image](https://github.com/comworkio/gh-versioning/assets/68862589/74f47adb-6c32-43c3-8370-9fd63ec1864d)
